### PR TITLE
Support installation on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use the included `setup.py` script:
 
 or manually copy the files to your Inkscape extensions directory.
 
-On Linux this is usually `~/.config/inkscape/extensions` and on Windows it is `%APPDATA%\inkscape\extensions`.
+On Unix-like systems (including Linux and Mac OS X) this is usually `~/.config/inkscape/extensions` and on Windows it is `%APPDATA%\inkscape\extensions`.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ import sys
 import argparse
 
 def install():
-    if sys.platform.startswith('linux'):
-        dest_path = os.path.join(os.environ['HOME'], '.config', 'inkscape', 'extensions')
-    elif sys.platform.startswith('win'):
+    if sys.platform.startswith('win'):
         dest_path = os.path.join(os.environ['APPDATA'], 'inkscape', 'extensions')
+    else:
+        dest_path = os.path.join(os.environ['HOME'], '.config', 'inkscape', 'extensions')
 
     current_dir = sys.path[0]
 


### PR DESCRIPTION
Mac OS uses the same path as Linux for Inkscape extensions, so I changed the install script and README to reflect this.