### PR TITLE
Avoid deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use the included `setup.py` script:
 
     python setup.py install
 
-or manually copy the files to your Inkscape extensions directory.
+or manually copy the files `set_css_class.inx` and `set_css_class.py` to your Inkscape extensions directory.
 
 On Unix-like systems (including Linux and Mac OS X) this is usually `~/.config/inkscape/extensions` and on Windows it is `%APPDATA%\inkscape\extensions`.
 

--- a/set_css_class.inx
+++ b/set_css_class.inx
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-  <_name>Set CSS class on elements</_name>
+  <name>Set CSS class on elements</name>
   <id>org.inkscape.stylesheet.set</id>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
   <dependency type="executable" location="extensions">set_css_class.py</dependency>
 
   <_param name="introduction" type="description">Set a CSS class on the selected elements. Their current inline styles will be removed.</_param>

--- a/set_css_class.py
+++ b/set_css_class.py
@@ -38,7 +38,7 @@ class SetCSSClass(inkex.Effect):
                 current_classes.append(newclass)
 
             if self.options.clear_styles:
-                el.attrib["style"] = ""
+                el.attrib.pop("style", None)
 
             el.attrib["class"] = " ".join(current_classes)
 

--- a/set_css_class.py
+++ b/set_css_class.py
@@ -18,18 +18,18 @@ import sys
 class SetCSSClass(inkex.Effect):
     def __init__(self):
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option("-n", "--name",
-                                     action="store", type="string",
+        self.arg_parser.add_argument("-n", "--name",
+                                     type=str,
                                      dest="name", default="",
                                      help="Name of css class to apply")
-        self.OptionParser.add_option("-c", "--clear_styles",
-                                     action="store", type="inkbool",
+        self.arg_parser.add_argument("-c", "--clear_styles",
+                                     type=inkex.Boolean,
                                      dest="clear_styles", default=True,
                                      help="Name of css class to apply")
 
     def effect(self):
         newclass = self.options.name
-        elements = self.selected.values()
+        elements = self.svg.selected.values()
 
         for el in elements:
             current_classes = el.attrib.has_key("class") and el.attrib["class"].split() or []
@@ -44,4 +44,4 @@ class SetCSSClass(inkex.Effect):
 
 if __name__ == "__main__":
     e = SetCSSClass()
-    e.affect()
+    e.run()


### PR DESCRIPTION
Thanks for developing this useful extension. It still works with Inkscape 1.1 but causes a dialog with deprecation warnings which are avoided with this proposed pull request. Additionally the pull request removes empty "style" attributes and clarifies the `README.md` file. Feel free to accept all, a subset or none of this pull request. ;-)